### PR TITLE
Enhance task_output_view and workflow

### DIFF
--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -10,10 +10,10 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4.1.1
 
     - name: 🛤 Setup Java
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4.0.0
       with:
         distribution: 'zulu'
         java-version: '11'
@@ -29,3 +29,9 @@ jobs:
       run: |
         flutter pub get
         flutter build apk --release --split-per-abi --no-pub
+
+    - name: Upload APK
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: release-apk
+        path: build/app/outputs/apk/

--- a/lib/components/task_output_view.dart
+++ b/lib/components/task_output_view.dart
@@ -9,11 +9,23 @@ import 'package:semaphore/adaptive/icon.dart';
 import 'package:semaphore/adaptive/icon_button.dart';
 import 'package:semaphore/components/status_chip.dart';
 import 'package:semaphore/state/projects/task.dart';
+import 'package:flutter/material.dart';
 
 class TaskOutputView extends ConsumerWidget {
   final int id;
 
   const TaskOutputView({super.key, required this.id});
+
+  static const Map<String, Color> colorMap = {
+    '30': Colors.black,
+    '31': Colors.red,
+    '32': Colors.green,
+    '33': Colors.yellow,
+    '34': Colors.blue,
+    '35': Colors.purple,
+    '36': Colors.cyan,
+    '37': Colors.white
+  };
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -67,30 +79,43 @@ class TaskOutputView extends ConsumerWidget {
                 const SizedBox(height: 12),
                 Expanded(
                   child: SingleChildScrollView(
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: taskOutput
-                          .map((line) => SelectableText.rich(TextSpan(
-                                  text: line.time?.toLocal().toString() ?? '',
-                                  style: GoogleFonts.robotoMono(
-                                    textStyle: TextStyle(
-                                        color: isDark
-                                            ? Colors.lightGreenAccent
-                                            : Colors.lightGreen),
-                                  ),
-                                  children: <InlineSpan>[
-                                    const TextSpan(text: '\t'),
-                                    TextSpan(
-                                      text: line.output?.replaceAll(
-                                              RegExp(r'\u001b\[([0-9;]+)m'),
-                                              '') ??
-                                          '',
-                                      style: GoogleFonts.robotoMono(
-                                        textStyle: TextStyle(color: textColor),
-                                      ),
+                    child: SingleChildScrollView(
+                      scrollDirection: Axis.horizontal,
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: taskOutput
+                            .map((line) => SelectableText.rich(
+                                  TextSpan(
+                                    text: line.time?.toLocal().toString() ?? '',
+                                    style: GoogleFonts.robotoMono(
+                                      textStyle: TextStyle(
+                                          color: isDark
+                                              ? Colors.lightGreenAccent
+                                              : Colors.lightGreen),
                                     ),
-                                  ])))
-                          .toList(),
+                                    children: <InlineSpan>[
+                                      const TextSpan(text: '\t'),
+                                      TextSpan(
+                                        text: line.output?.replaceAll(
+                                                RegExp(r'\u001b\[([0-9;]+)m'),
+                                                '') ??
+                                            '',
+                                        style: GoogleFonts.robotoMono(
+                                          textStyle: TextStyle(
+                                            color: line.output == null
+                                                ? textColor
+                                                : colorMap[RegExp(r'\u001b\[[0-9];([0-9]+)m')
+                                                            .firstMatch(
+                                                                line.output!)
+                                                            ?.group(1)] ?? textColor ,
+                                          ),
+                                        ), // GoogleFonts.robotoMono
+                                      ),
+                                    ],
+                                  ),
+                                ))
+                            .toList(),
+                      ),
                     ),
                   ),
                 ),

--- a/lib/components/task_output_view.dart
+++ b/lib/components/task_output_view.dart
@@ -89,21 +89,18 @@ class TaskOutputView extends ConsumerWidget {
           List<String> segments = line.output?.split('\u001b[0m') ?? [];
           
             for (String segment in segments) {
-              Color textColor;
+              Color specificColor;
 
               // Check if the segment matches the color code pattern
               if (colorRegex.hasMatch(segment)) {
-                String colorCode = colorRegex.firstMatch(segment)?.group(1);
-                textColor = colorMap[colorCode] ?? textColor;
-              } else {
-                // If the segment does not match the color code pattern, apply the default text color
-                textColor = textColor;
+                String colorCode = colorRegex.firstMatch(segment).group(1);
+                specificColor = colorMap[colorCode] ?? textColor;
               }
 
               coloredSegments.add(TextSpan(
                 text: segment.replaceAll(colorRegex, ''), // Remove color codes
                 style: GoogleFonts.robotoMono(
-                  textStyle: TextStyle(color: textColor),
+                  textStyle: TextStyle(color: specificColor ?? textColor),
                 ),
               ));
             }

--- a/lib/components/task_output_view.dart
+++ b/lib/components/task_output_view.dart
@@ -86,9 +86,8 @@ class TaskOutputView extends ConsumerWidget {
         children: taskOutput.map((line) {
           List<InlineSpan> coloredSegments = [];
           RegExp colorRegex = RegExp(r'\u001b\[[0-9];([0-9]+)m');
-          List<String> segments = line.output?.split('\u001b[0m');
-
-          if (segments != null) {
+          List<String> segments = line.output?.split('\u001b[0m') ?? [];
+          
             for (String segment in segments) {
               Color textColor;
 
@@ -108,7 +107,6 @@ class TaskOutputView extends ConsumerWidget {
                 ),
               ));
             }
-          }
 
           return SelectableText.rich(
             TextSpan(

--- a/lib/components/task_output_view.dart
+++ b/lib/components/task_output_view.dart
@@ -89,18 +89,18 @@ class TaskOutputView extends ConsumerWidget {
           List<String> segments = line.output?.split('\u001b[0m') ?? [];
           
             for (String segment in segments) {
-              Color specificColor;
+              Color specificColor = textColor;
 
               // Check if the segment matches the color code pattern
               if (colorRegex.hasMatch(segment)) {
-                String colorCode = colorRegex.firstMatch(segment).group(1);
+                String colorCode = colorRegex.firstMatch(segment)?.group(1) ?? '';
                 specificColor = colorMap[colorCode] ?? textColor;
               }
 
               coloredSegments.add(TextSpan(
                 text: segment.replaceAll(colorRegex, ''), // Remove color codes
                 style: GoogleFonts.robotoMono(
-                  textStyle: TextStyle(color: specificColor ?? textColor),
+                  textStyle: TextStyle(color: specificColor),
                 ),
               ));
             }

--- a/lib/components/task_output_view.dart
+++ b/lib/components/task_output_view.dart
@@ -95,25 +95,24 @@ class TaskOutputView extends ConsumerWidget {
                                     ),
                                     children: <InlineSpan>[
                                       const TextSpan(text: '\t'),
-                                      TextSpan(
-                                        text: line.output?.replaceAll(
+                                      ...line.output?.split('\u001b[0m').map(segment => 
+                                                                         TextSpan(
+                                        text: segment.replaceAll(
                                                 RegExp(r'\u001b\[([0-9;]+)m'),
                                                 '') ??
                                             '',
                                         style: GoogleFonts.robotoMono(
                                           textStyle: TextStyle(
-                                            color: line.output == null
+                                            color: segment == null
                                                 ? textColor
                                                 : colorMap[RegExp(r'\u001b\[[0-9];([0-9]+)m')
-                                                            .firstMatch(
-                                                                line.output!)
+                                                            .firstMatch(segment)
                                                             ?.group(1)] ?? textColor ,
                                           ),
                                         ), // GoogleFonts.robotoMono
                                       ),
-                                    ],
-                                  ),
-                                ))
+                                      ).toList(),
+                                    ])))
                             .toList(),
                       ),
                     ),


### PR DESCRIPTION
Added some minor tweaks to the formatting of the logs and to the pipeline. Would be fine for me to revert the changes for the pipeline. The modifications to the task_output_view improves readability of the log files. Maybe the colors can be adapted for light mode, but in general this improves the readability a lot (using dark mode, so i'm not sure about that):

* enhance task output view by colors and scroll instead of linebreaks
* pushing artifacts to action summary